### PR TITLE
pptsetup: Do not mess up the password when reading from stdin

### DIFF
--- a/pptpsetup
+++ b/pptpsetup
@@ -55,6 +55,7 @@ sub create {
     if ( !$PASSWORD ) {
         print "Password: ";
         $PASSWORD = <STDIN>;
+        chomp $PASSWORD;
         $PASSWORD =~ s/([^\x20\x21\x23-\x7e])/sprintf ("\\x%02x", ord ($1))/eg;
     }
 


### PR DESCRIPTION
Not sure whether this is the correct place to suggest patches, but the mailing list seems to be dead nowadays and here I see some commits newer than then newest post there so ;]

Before this patch the trailing newline, which Perl by default leaves, had been
included in the resulting configuration, thus having absolutely no chance to work
without passing it via `--password`, which is *super insecure* due to being
stored in shell's history and, quite often, showing up again in surprising ways.